### PR TITLE
Optimized version of rust phone_encoder with ibig (around ~x2 faster for me)

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -21,7 +21,7 @@ javac src/java/*.java -d build/java
 javac src/java/util/*.java -d build/util
 
 echo "Compiling Rust sources"
-cd src/rust/phone_encoder && cargo build --release && cp target/release/phone_encoder ../../../
+cd src/rust/phone_encoder && RUSTFLAGS="-Cprofile-use=$(pwd)/merged.profdata" cargo build --release && cp target/release/phone_encoder ../../../
 cd ../benchmark_runner && cargo build --release && cp target/release/benchmark_runner ../../../
 cd ../../..
 

--- a/src/rust/benchmark_runner/Cargo.toml
+++ b/src/rust/benchmark_runner/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libproc = "0.9.1"
+#libproc = "0.9.1"

--- a/src/rust/benchmark_runner/src/main.rs
+++ b/src/rust/benchmark_runner/src/main.rs
@@ -4,7 +4,7 @@ use std::process::*;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV4};
+// use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV4};
 
 fn main() {
     let mut args = args().skip(1);
@@ -18,7 +18,7 @@ fn main() {
         .stdout(Stdio::null())
         .spawn()
         .expect("process could not be created");
-    let pid = out.id() as i32;
+    // let pid = out.id() as i32;
 
     let mut mem: u64 = 0;
 
@@ -32,12 +32,12 @@ fn main() {
             break;
         } else {
             // the program seems to be still running, but we can still fail below
-            match pidrusage::<RUsageInfoV4>(pid) {
-                Ok(info) => {
-                    mem = max(mem, info.ri_resident_size);
-                }
-                Err(_) => break // ignore error because the process must have ended already
-            }
+            // match pidrusage::<RUsageInfoV4>(pid) {
+            //     Ok(info) => {
+            //         mem = max(mem, info.ri_resident_size);
+            //     }
+            //     Err(_) => break // ignore error because the process must have ended already
+            // }
             sleep(Duration::from_millis(5));
         }
     }

--- a/src/rust/phone_encoder/Cargo.toml
+++ b/src/rust/phone_encoder/Cargo.toml
@@ -8,4 +8,10 @@ license = ""
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+fnv = "1.0.7"
 ibig = "0.3.2"
+
+[profile.release]
+panic = "abort"
+opt-level = 3
+lto = "fat"

--- a/src/rust/phone_encoder/Cargo.toml
+++ b/src/rust/phone_encoder/Cargo.toml
@@ -8,5 +8,4 @@ license = ""
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-bigint = "0.4"
-lazy_static = "1.4.0"
+ibig = "0.3.2"

--- a/src/rust/phone_encoder/src/main.rs
+++ b/src/rust/phone_encoder/src/main.rs
@@ -4,15 +4,9 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
 
-use lazy_static::lazy_static;
-use num_bigint::{BigUint, ToBigUint};
+use ibig::{ubig, UBig};
 
-type Dictionary = HashMap<BigUint, Vec<String>>;
-
-lazy_static! {
-    static ref ONE: BigUint = 1.to_biguint().unwrap();
-    static ref TEN: BigUint =10.to_biguint().unwrap();
-}
+type Dictionary = HashMap<UBig, Vec<String>>;
 
 /// Port of Peter Norvig's Lisp solution to the Prechelt phone-encoding problem.
 ///
@@ -21,16 +15,22 @@ lazy_static! {
 fn main() -> io::Result<()> {
     // drop itself from args
     let mut args: Vec<_> = args().skip(1).collect();
-    let words_file: String = if !args.is_empty() { args.remove(0) } else { "tests/words.txt".into() };
-    let input_file: String = if !args.is_empty() { args.remove(0) } else { "tests/numbers.txt".into() };
+    let words_file: String = if !args.is_empty() {
+        args.remove(0)
+    } else {
+        "tests/words.txt".into()
+    };
+    let input_file: String = if !args.is_empty() {
+        args.remove(0)
+    } else {
+        "tests/numbers.txt".into()
+    };
 
     let dict = load_dict(words_file)?;
 
     for line in read_lines(input_file)? {
         if let Ok(num) = line {
-            let digits: Vec<_> = num.chars()
-                .filter(|ch| ch.is_alphanumeric())
-                .collect();
+            let digits: Vec<_> = num.chars().filter(|ch| ch.is_alphanumeric()).collect();
             print_translations(&num, &digits, 0, Vec::new(), &dict)?;
         }
     }
@@ -48,10 +48,10 @@ fn print_translations(
         print_solution(num, &words);
         return Ok(());
     }
-    let mut n = ONE.clone();
+    let mut n = ubig!(1);
     let mut found_word = false;
     for i in start..digits.len() {
-        n = &n * (&*TEN) + &nth_digit(digits, i);
+        n = &n * (ubig!(10)) + &nth_digit(digits, i);
         if let Some(found_words) = dict.get(&n) {
             for word in found_words {
                 found_word = true;
@@ -83,7 +83,8 @@ fn print_solution(num: &str, words: &Vec<&String>) {
     for word in head {
         print!("{} ", word);
     }
-    for word in tail { // only last word in tail
+    for word in tail {
+        // only last word in tail
         println!("{}", word);
     }
 }
@@ -104,42 +105,44 @@ fn load_dict(words_file: String) -> io::Result<Dictionary> {
 // The output is wrapped in a Result to allow matching on errors
 // Returns an Iterator to the Reader of the lines of the file.
 fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
-    where P: AsRef<Path>, {
+where
+    P: AsRef<Path>,
+{
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
 }
 
-fn word_to_number(word: &str) -> BigUint {
-    let mut n = ONE.clone();
+fn word_to_number(word: &str) -> UBig {
+    let mut n = ubig!(1);
     for ch in word.chars() {
         if ch.is_alphabetic() {
-            n = &n * (&*TEN) + &char_to_digit(ch);
+            n = &n * (ubig!(10)) + char_to_digit(ch);
         }
     }
     n
 }
 
-fn nth_digit(digits: &Vec<char>, i: usize) -> BigUint {
+fn nth_digit(digits: &Vec<char>, i: usize) -> UBig {
     let ch = digits.get(i).expect("index out of bounds");
-    ((*ch as usize) - ('0' as usize)).to_biguint().unwrap()
+    ((*ch as usize) - ('0' as usize)).into()
 }
 
 fn is_digit(string: &str) -> bool {
     string.len() == 1 && string.chars().next().unwrap().is_digit(10)
 }
 
-fn char_to_digit(ch: char) -> u32 {
+fn char_to_digit(ch: char) -> UBig {
     match ch.to_ascii_lowercase() {
-        'e' => 0,
-        'j' | 'n' | 'q' => 1,
-        'r' | 'w' | 'x' => 2,
-        'd' | 's' | 'y' => 3,
-        'f' | 't' => 4,
-        'a' | 'm' => 5,
-        'c' | 'i' | 'v' => 6,
-        'b' | 'k' | 'u' => 7,
-        'l' | 'o' | 'p' => 8,
-        'g' | 'h' | 'z' => 9,
-        _ => panic!("invalid input: not a digit: {}", ch)
+        'e' => ubig!(0),
+        'j' | 'n' | 'q' => ubig!(1),
+        'r' | 'w' | 'x' => ubig!(2),
+        'd' | 's' | 'y' => ubig!(3),
+        'f' | 't' => ubig!(4),
+        'a' | 'm' => ubig!(5),
+        'c' | 'i' | 'v' => ubig!(6),
+        'b' | 'k' | 'u' => ubig!(7),
+        'l' | 'o' | 'p' => ubig!(8),
+        'g' | 'h' | 'z' => ubig!(9),
+        _ => panic!("invalid input: not a digit: {}", ch),
     }
 }


### PR DESCRIPTION
I swapped num-bigint with ibig, which explicitly focuses on performance.
Also did some refactoring for it to look more Rusty and enabled Profile Guided Optimization.
That said, ibig yielded most gains.

Before:

> ===> java -cp build/java Main
Proc,Memory(bytes),Time(ms)
java,0,321
Proc,Memory(bytes),Time(ms)
java,0,438
Proc,Memory(bytes),Time(ms)
java,0,603
Proc,Memory(bytes),Time(ms)
java,0,718
===> java -cp build/java Main2
Proc,Memory(bytes),Time(ms)
java,0,305
Proc,Memory(bytes),Time(ms)
java,0,473
Proc,Memory(bytes),Time(ms)
java,0,1013
Proc,Memory(bytes),Time(ms)
java,0,1619
===> sbcl --script src/lisp/main.lisp
Proc,Memory(bytes),Time(ms)
sbcl,0,92
Proc,Memory(bytes),Time(ms)
sbcl,0,137
Proc,Memory(bytes),Time(ms)
sbcl,0,480
Proc,Memory(bytes),Time(ms)
sbcl,0,922
===> ./phone_encoder
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,97
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,194
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,649
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,1223
Cleaning up

After:

> ===> java -cp build/java Main
Proc,Memory(bytes),Time(ms)
java,0,325
Proc,Memory(bytes),Time(ms)
java,0,422
Proc,Memory(bytes),Time(ms)
java,0,619
Proc,Memory(bytes),Time(ms)
java,0,858
===> java -cp build/java Main2
Proc,Memory(bytes),Time(ms)
java,0,294
Proc,Memory(bytes),Time(ms)
java,0,524
Proc,Memory(bytes),Time(ms)
java,0,1244
Proc,Memory(bytes),Time(ms)
java,0,1702
===> sbcl --script src/lisp/main.lisp
Proc,Memory(bytes),Time(ms)
sbcl,0,86
Proc,Memory(bytes),Time(ms)
sbcl,0,147
Proc,Memory(bytes),Time(ms)
sbcl,0,513
Proc,Memory(bytes),Time(ms)
sbcl,0,875
===> ./phone_encoder
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,45
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,102
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,315
Proc,Memory(bytes),Time(ms)
./phone_encoder,0,616
Cleaning up

My setup: Archlinux with AMD Ryzen 7 4800H
